### PR TITLE
Extended 'format' parameter with 'raw', to send unadulterated data.

### DIFF
--- a/com.ibm.streamsx.tcp/com.ibm.streamsx.tcp/TCPServer/TCPServer.xml
+++ b/com.ibm.streamsx.tcp/com.ibm.streamsx.tcp/TCPServer/TCPServer.xml
@@ -137,6 +137,7 @@ The TCPServer operator throws an exception and terminates the operator in the fo
           <name>DataFormat</name>
           <value>block</value>
           <value>line</value>
+          <value>raw</value>
         </enumeration>
         <enumeration>
           <name>ShutdownMode</name>
@@ -221,7 +222,12 @@ The TCPServer operator throws an exception and terminates the operator in the fo
       </parameter>
       <parameter>
         <name>format</name>
-        <description>Format of the data on output port</description>
+        <description>Format of the data on output port
+
+* line - tuple data is transmitted in chucks terminated by a new line. If the final chunk is not terminated by a new line, a new line is provided. Input port should be of type TcpServerStrT. 
+* block - a 64 bit integer length is prepended to the begining of transmitted data. Input should be of type TcpServerBlobT 
+* raw -  data is transmitted with no adorment. Input port should be of type TcpServerBlobT.          
+</description>
         <optional>true</optional>
         <rewriteAllowed>false</rewriteAllowed>
         <expressionMode>CustomLiteral</expressionMode>

--- a/com.ibm.streamsx.tcp/com.ibm.streamsx.tcp/TCPServer/TCPServer_cpp.cgt
+++ b/com.ibm.streamsx.tcp/com.ibm.streamsx.tcp/TCPServer/TCPServer_cpp.cgt
@@ -39,7 +39,7 @@ using namespace SPL;
   } else {
       $blockSize = $blockSize->getValueAt(0)->getCppExpression();
   }
-
+  
   my $keepAlive = $model->getParameterByName("keepAlive");
   # Apply default value for keepAlive.
   $keepAlive = $keepAlive ? $keepAlive->getValueAt(0)->getCppExpression() : "";
@@ -154,6 +154,7 @@ void MY_OPERATOR::handleData(std::string & line, std::string const & ipAddress, 
     <%}%>
 
 
+
     <%if ($oport0->getAttributeByName("srcIP")) {%>
         otuple0_->get_srcIP() = ipAddress;
     <%}%>
@@ -198,6 +199,11 @@ void MY_OPERATOR::handleWrite(std::string const & line, std::string const & ipAd
 void MY_OPERATOR::handleWrite(SPL::blob const & raw, std::string const & ipAddress, uint32_t port)
 {
 	server_.handleWrite(const_cast<SPL::blob &>(raw), false, ipAddress, port);
+}
+// Send the data unadulterated - raw
+void MY_OPERATOR::handleRawWrite(SPL::blob const & raw, std::string const & ipAddress, uint32_t port)
+{
+	server_.handleWrite(const_cast<SPL::blob &>(raw), true, ipAddress, port);
 }
 
 void MY_OPERATOR::handleError(const streams_boost::system::error_code& e, std::string const & ipAddress, uint32_t port)
@@ -246,19 +252,26 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port)
 	const uint32_t destPort = (uint32_t)t.get_srcPort();
 	<%}%>
 
-	// if data is rstring, call handleWrite(string, ipAddress, port)	
+	
+	// if data is rstring, call handleWrite(string, ipAddress, port)
+	<%
+	# How do you get the value of format at compile time?? 
+	%>
 	<%if ($iport0->getAttributeByName("line")){%>
-		
-		std::string const & line = t.get_line();
+		std::string const & line = t.get_line();  // line
 		handleWrite(line, destIp, destPort);
-		
-	// else if idata is a blob, call handleWrite(blob, ipAddress, port)		
-	<%}else{%>
-		
-		SPL::blob const & block = t.get_block();
-		handleWrite(block, destIp, destPort);
+	<%} else {%>
+     // else if idata is a blob, call handleWrite(blob, ipAddress, port)
+		SPL::blob const & block = t.get_block();        
+        if ("block" == param$format$0) {
+			handleWrite(block, destIp, destPort);  // block 
+			// std::cout << "block" << std::endl;			
+		} else {
+			handleRawWrite(block, destIp, destPort);  // raw
+			// std::cout << "raw" << std::endl;
+		}	 
 	<%}%>
-	<%}%>
+	<%}%>	
 }
 
 <%SPL::CodeGen::implementationEpilogue($model);%>

--- a/com.ibm.streamsx.tcp/com.ibm.streamsx.tcp/TCPServer/TCPServer_h.cgt
+++ b/com.ibm.streamsx.tcp/com.ibm.streamsx.tcp/TCPServer/TCPServer_h.cgt
@@ -50,6 +50,7 @@ public:
 	// For handling string data from a stream and writing it to a client 
 	void handleWrite(std::string const & line, std::string const & ipAddress, uint32_t port);
 	void handleWrite(SPL::blob const & raw, std::string const & ipAddress, uint32_t port);
+	void handleRawWrite(SPL::blob const & raw, std::string const & ipAddress, uint32_t port);
 
 	// For handling errors when writing data to a client 
 	void handleError(const streams_boost::system::error_code& e, std::string const & ipAddress, uint32_t port);

--- a/com.ibm.streamsx.tcp/samples/TCPServerSendRaw/sample/TCPServerSendRaw.spl
+++ b/com.ibm.streamsx.tcp/samples/TCPServerSendRaw/sample/TCPServerSendRaw.spl
@@ -1,0 +1,97 @@
+namespace sample;
+
+use com.ibm.streamsx.tcp::*;
+
+use com.ibm.streamsx.tcp::TCPServer ;
+use com.ibm.streamsx.tcp::TcpServerBlobT ;
+use com.ibm.streamsx.tcp::TcpServerStatusT ;
+use com.ibm.streamsx.tcp::TcpServerStrT ;
+/*
+ * Example of using the format parameter of on TCPServer opertor. 
+ * What todo; 
+ * 1) Build this sample.
+ * 2) Deploy it. 
+ * 3) Get the IP address of the node your running on. 
+ * 4) Use nc (netcat) to access the node/port, for example. 
+ *        nc 192.12.23.134 8819  > /tmp/log.out
+ * 5) Wait ~ 10 seconds for the data to be sent, I have delay.
+ *
+ * What to look for... 
+ *   The log.out file should have 'tmpStr' below repeated 10 times, 
+ *   Their should be NO extra characters between lines, that 
+ *   is no count and no '\n'
+ * 
+ */
+composite TCPServerSendRaw
+{
+	param
+		expression<uint32> $PORT : 8819u ;
+		expression<rstring> $ADDRESS : getIPAddress() ;
+	graph
+		() as FileSink_2 = FileSink(TcpConnect as InputStreamConnect)
+		{
+			param
+				file : "/dev/stdout" ;
+				format : csv ;
+				flush : 1u ;
+		}
+
+		() as FileSink_1 = FileSink(TcpData as InputStreamName0)
+		{
+			param
+				file : "/tmp/outputPort.csv" ;
+				format : csv ;
+				flush : 1u ;
+		}
+
+		(stream<TcpServerStrT> TcpData ; stream<TcpServerStatusT> TcpConnect) as
+			TCPServerTransmit = TCPServer(Delay_5_out0)
+		{
+			param
+				port : $PORT ;
+				threadPoolSize : 10u ;
+				format : TCPServer.raw ; 	
+				connectionCap : 5u ;
+				blockSize : 4096u ;
+				address : $ADDRESS ;
+		}
+
+		(stream<TcpServerBlobT> Custom_4_out0 as outP) as Custom_4 = Custom(TcpConnect as inP) // blob ?  v2
+
+		{
+			logic
+				state :
+				{
+					mutable TcpServerBlobT outMsg ;         // blob   v2
+					mutable int64 idx = 0 ;
+					mutable rstring tmpStr ;
+				}
+
+				onTuple TcpConnect :
+				{
+					if(inP.status != "connected")
+					{
+						return ;
+					}
+
+					assignFrom(outMsg, inP) ;
+					for(int32 i in range(1, 10))
+					{
+						tmpStr =
+							"123456789012345678901234567890123456789012345678bbb9012345678901234567890123456789012345678901234567890:"
+							+(rstring) idx ++ ;
+						println("msg:" + tmpStr) ;
+						outMsg.block = convertToBlob(tmpStr) ;// blob ? v2
+						submit(outMsg, outP) ;
+					}
+
+				}
+		}
+
+		(stream<Custom_4_out0> Delay_5_out0) as Delay_5 = Delay(Custom_4_out0)
+		{
+			param
+				delay : 1.0 ;
+		}
+
+}


### PR DESCRIPTION
This was necessary to address a POC issue. We're transmitting messages in
a format specified by a hardware vender. The vender cannot interpret
messages sent in the 'line' or 'block' format.

Extended the format parameter with 'raw', it indicates that the data
should be transmitted unaugmented.

Added a sample with explaination of what to look when using.

modified:   TCPServer.xml
modified:   TCPServer_cpp.cgt
modified:   TCPServer_h.cgt
new file:   ../../samples/TCPServerSendRaw/sample/TCPServerSendRaw.spl